### PR TITLE
Small fixes for Dockerfile and dataset download scripts

### DIFF
--- a/data/download.sh
+++ b/data/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 mkdir FlyingThings3D_release
 cd FlyingThings3D_release
@@ -9,8 +9,8 @@ wget http://lmb.informatik.uni-freiburg.de/data/SceneFlowDatasets_CVPR16/Release
 tar xvf flyingthings3d__frames_cleanpass.tar
 tar xvf flyingthings3d__optical_flow.tar.bz2
 
-cd .. 
-wget http://lmb.informatik.uni-freiburg.de/resources/datasets/FlyingChairs/FlyingChairs.zip
+cd ..
+wget http://lmb.informatik.uni-freiburg.de/data/FlyingChairs/FlyingChairs.zip
 unzip FlyingChairs.zip
 
 wget https://lmb.informatik.uni-freiburg.de/data/FlowNet2/ChairsSDHom/ChairsSDHom.tar.gz

--- a/docker/standalone/gpu/Dockerfile
+++ b/docker/standalone/gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:7.5-cudnn5-devel-ubuntu14.04
+FROM nvidia/cuda:8.0-cudnn5-devel-ubuntu14.04
 MAINTAINER caffe-maint@googlegroups.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Two fixes:
1) Use new URL for flying chairs dataset
2) Fix "nvcc fatal   : Unsupported gpu architecture 'compute_60'" error when building caffe in dockerfile by using CUDA 8.0 instead of 7.5