### PR TITLE
Update resample_layer.cu

### DIFF
--- a/src/caffe/layers/resample_layer.cu
+++ b/src/caffe/layers/resample_layer.cu
@@ -7,7 +7,7 @@
 #include "caffe/util/math_functions.hpp"
 
 #include <opencv2/opencv.hpp>
-#include <opencv2/gpu/gpu.hpp>
+//#include <opencv2/gpu/gpu.hpp>
 
 namespace caffe {
 


### PR DESCRIPTION
comment this line"//#include <opencv2/gpu/gpu.hpp>", cv::gpu is not used in this file. And if you opencv is compiled without gpu, a problem will appear.